### PR TITLE
Refresh landing page with dark technocratic styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,18 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
   <style>
     :root {
-      --bg-dark: #050314;
-      --bg-light: #f5f7ff;
-      --text-primary: #121122;
-      --text-secondary: rgba(18, 17, 34, 0.7);
-      --accent: #5e4ff7;
-      --accent-soft: rgba(94, 79, 247, 0.18);
-      --accent-strong: rgba(94, 79, 247, 0.8);
-      --code-bg: rgba(18, 17, 34, 0.08);
-      --code-text: #2a2473;
-      --border: rgba(18, 17, 34, 0.08);
+      --bg-dark: #040510;
+      --bg-deep: #010208;
+      --bg-panel: rgba(17, 21, 35, 0.6);
+      --bg-panel-strong: rgba(21, 27, 46, 0.92);
+      --text-primary: #f4f7ff;
+      --text-secondary: rgba(226, 231, 255, 0.72);
+      --accent: #5c8dff;
+      --accent-soft: rgba(92, 141, 255, 0.2);
+      --accent-strong: rgba(92, 141, 255, 0.8);
+      --code-bg: rgba(12, 16, 28, 0.72);
+      --code-text: #c7d9ff;
+      --border: rgba(124, 156, 255, 0.16);
       --max-width: 1100px;
     }
 
@@ -30,9 +32,35 @@
       margin: 0;
       font-family: 'Inter', sans-serif;
       color: var(--text-primary);
-      background: var(--bg-light);
+      background: radial-gradient(circle at 20% 20%, rgba(64, 94, 255, 0.08), transparent 55%),
+        radial-gradient(circle at 80% 10%, rgba(114, 58, 255, 0.12), transparent 45%), var(--bg-dark);
       line-height: 1.6;
       overflow-x: hidden;
+      position: relative;
+      min-height: 100vh;
+    }
+
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: repeating-linear-gradient(
+          90deg,
+          rgba(160, 186, 255, 0.04) 0px,
+          rgba(160, 186, 255, 0.04) 1px,
+          transparent 1px,
+          transparent 80px
+        ),
+        repeating-linear-gradient(
+          0deg,
+          rgba(160, 186, 255, 0.05) 0px,
+          rgba(160, 186, 255, 0.05) 1px,
+          transparent 1px,
+          transparent 80px
+        );
+      opacity: 0.35;
+      pointer-events: none;
+      z-index: -1;
     }
 
     h1, h2, h3 {
@@ -53,25 +81,23 @@
     .hero {
       min-height: 100vh;
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: center;
       text-align: center;
       color: #fff;
       position: relative;
       overflow: hidden;
-      background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.06), transparent 60%),
-        radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.08), transparent 65%),
-        var(--bg-dark);
+      background: linear-gradient(160deg, rgba(13, 20, 40, 0.92), rgba(4, 5, 16, 0.98));
     }
 
     .hero::before {
       content: '';
       position: absolute;
       inset: -150px;
-      background: linear-gradient(120deg, rgba(94, 79, 247, 0.45), rgba(44, 180, 255, 0.35), rgba(255, 119, 221, 0.25));
-      filter: blur(120px);
-      animation: drift 14s ease-in-out infinite alternate;
-      opacity: 0.8;
+      background: linear-gradient(120deg, rgba(92, 141, 255, 0.55), rgba(73, 215, 255, 0.38), rgba(150, 82, 255, 0.32));
+      filter: blur(150px);
+      animation: drift 18s ease-in-out infinite alternate;
+      opacity: 0.75;
     }
 
     @keyframes drift {
@@ -90,13 +116,17 @@
       position: relative;
       max-width: 780px;
       z-index: 1;
-      padding: 0 24px;
+      padding: clamp(60px, 12vh, 160px) 24px 24px;
+      animation: fadeUp 1.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+      opacity: 0;
+      transform: translate3d(0, 40px, 0);
     }
 
     .hero h1 {
       font-size: clamp(2.5rem, 6vw, 4.25rem);
       letter-spacing: -0.02em;
-      margin-bottom: 1.5rem;
+      margin-bottom: 1.35rem;
+      line-height: 1.05;
     }
 
     .hero p {
@@ -104,21 +134,24 @@
       font-weight: 400;
       color: rgba(255, 255, 255, 0.8);
       margin-bottom: 2.5rem;
+      line-height: 1.6;
     }
 
     .hero .logos {
       display: inline-flex;
       align-items: center;
       gap: 0.6rem;
-      padding: 0.75rem 1.5rem;
-      background: rgba(255, 255, 255, 0.06);
+      padding: 0.85rem 1.8rem;
+      background: rgba(12, 16, 30, 0.75);
       border-radius: 999px;
       font-weight: 500;
       font-size: 1rem;
+      box-shadow: 0 18px 40px rgba(28, 53, 120, 0.32);
+      border: 1px solid rgba(160, 186, 255, 0.2);
     }
 
     .hero .scroll-hint {
-      margin-top: 80px;
+      margin-top: 96px;
       font-size: 0.95rem;
       letter-spacing: 0.1em;
       text-transform: uppercase;
@@ -162,7 +195,7 @@
     }
 
     .intro {
-      background: #fff;
+      background: linear-gradient(180deg, rgba(7, 10, 22, 0.95) 0%, rgba(5, 7, 18, 0.98) 100%);
     }
 
     .intro-content {
@@ -172,6 +205,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 64px;
       align-items: start;
+      color: var(--text-secondary);
     }
 
     .intro p {
@@ -189,12 +223,16 @@
       position: relative;
       padding: 24px;
       border-radius: 20px;
-      background: rgba(94, 79, 247, 0.08);
-      backdrop-filter: blur(6px);
-      border: 1px solid rgba(94, 79, 247, 0.15);
+      background: var(--bg-panel);
+      backdrop-filter: blur(12px);
+      border: 1px solid rgba(124, 156, 255, 0.22);
       color: var(--text-primary);
       font-weight: 500;
       line-height: 1.5;
+      box-shadow: 0 24px 60px rgba(10, 14, 28, 0.4);
+      animation: fadeUp 1.2s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+      opacity: 0;
+      transform: translate3d(0, 40px, 0);
     }
 
     .intro .highlight-card::before {
@@ -205,9 +243,9 @@
       width: 42px;
       height: 42px;
       border-radius: 12px;
-      background: linear-gradient(135deg, rgba(94, 79, 247, 0.4), rgba(44, 180, 255, 0.4));
-      opacity: 0.5;
-      animation: shimmer 8s ease-in-out infinite;
+      background: linear-gradient(135deg, rgba(92, 141, 255, 0.45), rgba(67, 207, 255, 0.45));
+      opacity: 0.35;
+      animation: shimmer 10s ease-in-out infinite;
     }
 
     @keyframes shimmer {
@@ -220,7 +258,7 @@
     }
 
     .guide {
-      background: linear-gradient(180deg, #f5f7ff 0%, #ffffff 60%, #f7f9ff 100%);
+      background: linear-gradient(180deg, rgba(4, 6, 16, 0.98) 0%, rgba(3, 4, 12, 0.96) 100%);
     }
 
     .guide-wrapper {
@@ -230,6 +268,7 @@
       grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.2fr);
       gap: 56px;
       align-items: start;
+      color: var(--text-secondary);
     }
 
     .sticky-visual {
@@ -239,11 +278,11 @@
     }
 
     .visual-card {
-      background: #fff;
+      background: var(--bg-panel-strong);
       border-radius: 28px;
       padding: 48px 40px;
-      box-shadow: 0 30px 70px rgba(20, 25, 80, 0.12);
-      border: 1px solid rgba(94, 79, 247, 0.15);
+      box-shadow: 0 30px 80px rgba(4, 5, 18, 0.7);
+      border: 1px solid rgba(124, 156, 255, 0.22);
       min-height: 380px;
       display: flex;
       flex-direction: column;
@@ -253,23 +292,24 @@
 
     .visual-card.active {
       transform: translateY(-6px);
-      box-shadow: 0 40px 90px rgba(20, 25, 80, 0.16);
+      box-shadow: 0 40px 110px rgba(3, 6, 18, 0.85);
     }
 
     .visual-icon {
       width: 78px;
       height: 78px;
       border-radius: 24px;
-      background: linear-gradient(135deg, rgba(94, 79, 247, 0.18), rgba(44, 180, 255, 0.18));
+      background: linear-gradient(135deg, rgba(92, 141, 255, 0.25), rgba(67, 207, 255, 0.25));
       display: grid;
       place-items: center;
       font-size: 34px;
-      color: var(--accent);
+      color: #fff;
     }
 
     .visual-title {
       font-size: 1.5rem;
       font-weight: 600;
+      color: var(--text-primary);
     }
 
     .visual-description {
@@ -283,17 +323,19 @@
     }
 
     .step {
-      background: rgba(255, 255, 255, 0.85);
+      background: rgba(11, 16, 30, 0.85);
       border: 1px solid var(--border);
       border-radius: 22px;
       padding: 28px;
-      transition: border-color 0.3s ease, box-shadow 0.3s ease;
+      transition: border-color 0.4s ease, box-shadow 0.4s ease, transform 0.4s ease;
       position: relative;
+      color: var(--text-secondary);
     }
 
     .step.active {
       border-color: var(--accent-strong);
-      box-shadow: 0 20px 40px rgba(94, 79, 247, 0.12);
+      box-shadow: 0 26px 60px rgba(23, 42, 94, 0.35);
+      transform: translateY(-4px);
     }
 
     .step-number {
@@ -303,8 +345,8 @@
       width: 42px;
       height: 42px;
       border-radius: 14px;
-      background: rgba(94, 79, 247, 0.15);
-      color: var(--accent);
+      background: rgba(92, 141, 255, 0.18);
+      color: var(--text-primary);
       font-weight: 600;
       margin-bottom: 16px;
       font-size: 1.1rem;
@@ -322,13 +364,14 @@
     .copy-box {
       position: relative;
       padding: 18px 24px;
-      background: rgba(18, 17, 34, 0.04);
+      background: rgba(7, 10, 22, 0.8);
       border-radius: 16px;
-      border: 1px solid rgba(18, 17, 34, 0.1);
+      border: 1px solid rgba(124, 156, 255, 0.18);
       margin-top: 16px;
       font-family: 'Fira Code', monospace;
       font-size: 0.95rem;
       color: var(--text-primary);
+      box-shadow: inset 0 0 40px rgba(12, 18, 38, 0.6);
     }
 
     .copy-button {
@@ -336,18 +379,19 @@
       top: 12px;
       right: 12px;
       border: none;
-      background: rgba(94, 79, 247, 0.12);
-      color: var(--accent);
+      background: rgba(92, 141, 255, 0.2);
+      color: var(--text-primary);
       padding: 6px 12px;
       border-radius: 999px;
       font-family: 'Inter', sans-serif;
       font-size: 0.85rem;
       cursor: pointer;
-      transition: background 0.3s ease, color 0.3s ease;
+      transition: background 0.3s ease, color 0.3s ease, transform 0.3s ease;
     }
 
     .copy-button:hover {
-      background: rgba(94, 79, 247, 0.2);
+      background: rgba(92, 141, 255, 0.32);
+      transform: translateY(-1px);
     }
 
     .copy-button.copied {
@@ -356,7 +400,7 @@
     }
 
     .payoff {
-      background: linear-gradient(180deg, #ffffff 0%, #eef2ff 100%);
+      background: linear-gradient(180deg, rgba(3, 4, 12, 0.96) 0%, rgba(2, 3, 9, 0.98) 100%);
     }
 
     .payoff .content {
@@ -366,14 +410,15 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 48px;
       align-items: center;
+      color: var(--text-secondary);
     }
 
     .automation-visual {
-      background: #fff;
+      background: var(--bg-panel-strong);
       border-radius: 24px;
       padding: 32px;
-      box-shadow: 0 30px 80px rgba(94, 79, 247, 0.15);
-      border: 1px solid rgba(94, 79, 247, 0.2);
+      box-shadow: 0 40px 120px rgba(3, 6, 18, 0.8);
+      border: 1px solid rgba(124, 156, 255, 0.22);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -394,8 +439,8 @@
       position: relative;
       padding: 10px 18px;
       border-radius: 14px;
-      background: rgba(94, 79, 247, 0.1);
-      border: 1px solid rgba(94, 79, 247, 0.25);
+      background: rgba(92, 141, 255, 0.18);
+      border: 1px solid rgba(124, 156, 255, 0.35);
     }
 
     .automation-flow span::after {
@@ -427,7 +472,7 @@
     }
 
     .cta {
-      background: var(--bg-dark);
+      background: linear-gradient(180deg, rgba(2, 3, 9, 0.98) 0%, rgba(1, 2, 6, 0.98) 100%);
       color: #fff;
       text-align: center;
       padding: 140px 24px 160px;
@@ -435,25 +480,22 @@
 
     .cta h2 {
       font-size: clamp(2rem, 5vw, 3.2rem);
-      margin-bottom: 32px;
+      margin-bottom: 16px;
+      line-height: 1.08;
     }
 
-    .cta button {
-      background: linear-gradient(135deg, rgba(94, 79, 247, 1), rgba(44, 180, 255, 1));
-      border: none;
-      border-radius: 999px;
-      padding: 18px 48px;
-      font-size: 1.1rem;
-      font-weight: 600;
-      color: #fff;
-      cursor: pointer;
-      box-shadow: 0 24px 50px rgba(94, 79, 247, 0.35);
-      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    .cta p {
+      color: var(--text-secondary);
+      font-size: 1.05rem;
+      margin: 0 auto;
+      max-width: 620px;
     }
 
-    .cta button:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 32px 60px rgba(94, 79, 247, 0.45);
+    @keyframes fadeUp {
+      to {
+        opacity: 1;
+        transform: translate3d(0, 0, 0);
+      }
     }
 
     @media (max-width: 1024px) {
@@ -618,7 +660,7 @@
 
   <section class="cta">
     <h2>My recommendation is to try this process just once, today.</h2>
-    <button type="button" aria-label="Give it a try today">Give it a try today</button>
+    <p>Give yourself an evening to wire these tools together—the payoff is a repeatable launchpad for every new idea.</p>
   </section>
 
   <script>


### PR DESCRIPTION
## Summary
- restyled the landing page with a darker technocratic palette, subtle grid backdrop, and soft entrance animations
- refined hero spacing by adding breathing room above the logo chips and tightening the headline leading for stronger hierarchy
- removed the inactive bottom CTA button and replaced it with supporting copy that matches the new tone

## Testing
- not run (static page)


------
https://chatgpt.com/codex/tasks/task_e_68e5049a83b88331950fdeb10115ac13